### PR TITLE
Add license file

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,7 @@ test:
 about:
   home: http://bitbucket.org/shimizukawa/sphinxjp.themecore
   license: MIT
-  # FIXME: add license file once added by upstream
-  #license_file: LICENSE.txt
+  license_file: src/LICENSE.txt
   summary: 'A sphinx theme plugin support extension. #sphinxjp'
 
 extra:


### PR DESCRIPTION
The license file was already included in the release tarball (see [here](https://bitbucket.org/shimizukawa/sphinxjp.themecore/issues/2/missing-license-text)).
